### PR TITLE
Security hardening: input validation, SQL injection prevention, and XSS fixes

### DIFF
--- a/includes/class-admin-audit.php
+++ b/includes/class-admin-audit.php
@@ -344,12 +344,22 @@ class InterSoccer_Admin_Audit {
      * Get unique values for filter dropdowns
      */
     private function get_unique_values($column) {
+        // Whitelist allowed column names to prevent SQL injection via column interpolation.
+        $allowed_columns = [ 'event_type', 'category' ];
+        if ( ! in_array( $column, $allowed_columns, true ) ) {
+            return [];
+        }
+
         global $wpdb;
         $table_name = $wpdb->prefix . 'intersoccer_audit_log';
 
-        $results = $wpdb->get_col($wpdb->prepare(
-            "SELECT DISTINCT {$column} FROM {$table_name} WHERE {$column} != '' ORDER BY {$column} LIMIT 100"
-        ));
+        // $column is safe after the whitelist check above; backtick-quote it for clarity.
+        $quoted_column = '`' . $column . '`';
+
+        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- column name is whitelisted above
+        $results = $wpdb->get_col(
+            "SELECT DISTINCT {$quoted_column} FROM {$table_name} WHERE {$quoted_column} != '' ORDER BY {$quoted_column} LIMIT 100"
+        );
 
         return $results ?: [];
     }

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -2065,7 +2065,8 @@ class InterSoccer_Admin_Settings {
         ];
 
         foreach ($tables as $table) {
-            if ($wpdb->get_var("SHOW TABLES LIKE '$table'") !== $table) {
+            // Use $wpdb->prepare() to prevent potential SQL injection via the table name placeholder.
+            if ($wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table)) !== $table) {
                 return false;
             }
         }
@@ -2237,27 +2238,22 @@ class InterSoccer_Admin_Settings {
      */
     public function ajax_import_coaches_from_csv() {
         try {
-            // Debug logging
-            intersoccer_referral_log('AJAX import called at ' . current_time('mysql'));
-            intersoccer_referral_log('POST data: ' . print_r($_POST, true));
-            intersoccer_referral_log('FILES data: ' . print_r($_FILES, true));
-
-            // Verify nonce and permissions
+            // Verify nonce and permissions before any logging to avoid leaking request data
             if (!wp_verify_nonce($_POST['_wpnonce'] ?? '', 'import_coaches_from_csv')) {
-                intersoccer_referral_log('Nonce verification failed');
+                intersoccer_referral_log('InterSoccer: Coach CSV AJAX import — nonce verification failed');
                 wp_send_json_error('Invalid nonce');
                 return;
             }
 
             if (!current_user_can('manage_options')) {
-                intersoccer_referral_log('Permission check failed');
+                intersoccer_referral_log('InterSoccer: Coach CSV AJAX import — permission check failed for user ' . get_current_user_id());
                 wp_send_json_error('Insufficient permissions');
                 return;
             }
 
             if (!isset($_FILES['coaches_csv']) || $_FILES['coaches_csv']['error'] !== UPLOAD_ERR_OK) {
-                $error_code = $_FILES['coaches_csv']['error'] ?? 'no file';
-                intersoccer_referral_log('File upload error: ' . $error_code);
+                $error_code = isset($_FILES['coaches_csv']['error']) ? (int) $_FILES['coaches_csv']['error'] : -1;
+                intersoccer_referral_log('InterSoccer: Coach CSV AJAX import — file upload error code: ' . $error_code);
                 wp_send_json_error('File upload error: ' . $error_code);
                 return;
             }
@@ -2265,7 +2261,7 @@ class InterSoccer_Admin_Settings {
             $file = $_FILES['coaches_csv']['tmp_name'];
             $update_existing = isset($_POST['update_existing']) && $_POST['update_existing'] == '1';
 
-            intersoccer_referral_log('Processing file: ' . $file . ', update_existing: ' . ($update_existing ? 'yes' : 'no'));
+            intersoccer_referral_log('InterSoccer: Coach CSV AJAX import started, update_existing: ' . ($update_existing ? 'yes' : 'no'));
 
             $results = $this->process_coach_csv_import($file, $update_existing);
 

--- a/includes/class-referral-handler.php
+++ b/includes/class-referral-handler.php
@@ -232,30 +232,47 @@ class InterSoccer_Referral_Handler {
 
     public function handle_gift_credits() {
         check_ajax_referer('intersoccer_dashboard_nonce');
-        $amount = floatval($_POST['gift_amount']);
-        $recipient = get_user_by('email', sanitize_email($_POST['recipient_email']));
-        $sender_id = get_current_user_id();
-        $sender_credits = intersoccer_get_customer_credits($sender_id);
-        if ($recipient && $amount >= 50 && $amount <= $sender_credits) {
-            update_user_meta($sender_id, 'intersoccer_customer_credits', $sender_credits - $amount);
-            update_user_meta($recipient->ID, 'intersoccer_customer_credits', intersoccer_get_customer_credits($recipient->ID) + $amount);
-            update_user_meta($sender_id, 'intersoccer_customer_credits', $sender_credits - $amount + 20); // Reciprocity bonus
-            
-            if (defined('WP_DEBUG') && WP_DEBUG) {
-                intersoccer_referral_log('InterSoccer Referral: Credits gifted - ' . $amount . ' from user ' . $sender_id . ' to ' . $recipient->ID);
-            }
-            
-            wp_send_json_success(['message' => 'Credits gifted! You earned a 20-point bonus!']);
+
+        if ( ! is_user_logged_in() ) {
+            wp_send_json_error( [ 'message' => 'Must be logged in' ] );
         }
-        wp_send_json_error(['message' => 'Invalid gift request']);
+
+        $amount    = floatval( $_POST['gift_amount'] );
+        $recipient = get_user_by( 'email', sanitize_email( $_POST['recipient_email'] ) );
+        $sender_id = get_current_user_id();
+
+        // Prevent self-gifting
+        if ( $recipient && (int) $recipient->ID === (int) $sender_id ) {
+            wp_send_json_error( [ 'message' => 'Cannot gift credits to yourself' ] );
+        }
+
+        $sender_credits = intersoccer_get_customer_credits( $sender_id );
+
+        if ( $recipient && $amount >= 50 && $amount <= $sender_credits ) {
+            // Deduct from sender first, then add bonus — using a single atomic-style update.
+            // The bonus (20 pts) is applied to the sender's balance AFTER the deduction so
+            // the net cost to the sender is ($amount - 20), not $amount.
+            $sender_new = $sender_credits - $amount + 20; // net: sender pays ($amount - 20)
+            update_user_meta( $sender_id, 'intersoccer_customer_credits', $sender_new );
+            update_user_meta( $recipient->ID, 'intersoccer_customer_credits', intersoccer_get_customer_credits( $recipient->ID ) + $amount );
+
+            if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                intersoccer_referral_log( 'InterSoccer Referral: Credits gifted - ' . $amount . ' from user ' . $sender_id . ' to ' . $recipient->ID );
+            }
+
+            wp_send_json_success( [ 'message' => 'Credits gifted! You earned a 20-point bonus!' ] );
+        }
+
+        wp_send_json_error( [ 'message' => 'Invalid gift request' ] );
     }
 
     public function render_gift_form() {
-        $credits = intersoccer_get_customer_credits();
+        $credits = (float) intersoccer_get_customer_credits();
+        $credits_escaped = esc_attr( number_format( $credits, 0, '.', '' ) );
         ?>
         <form id="gift-credits" method="post">
-            <label>Gift Points (Max <?php echo $credits; ?>):</label>
-            <input type="number" name="gift_amount" max="<?php echo $credits; ?>" min="50" step="10">
+            <label>Gift Points (Max <?php echo esc_html( number_format( $credits, 0 ) ); ?>):</label>
+            <input type="number" name="gift_amount" max="<?php echo $credits_escaped; ?>" min="50" step="10">
             <label>To User (Email):</label>
             <input type="email" name="recipient_email">
             <button type="submit">Gift</button>
@@ -332,6 +349,19 @@ class InterSoccer_Referral_Handler {
         $table_name = $wpdb->prefix . 'intersoccer_referrals';
         $referrer = $this->get_referrer_by_code($ref_code);
         if (!$referrer) return;
+
+        // Prevent self-referral: a customer cannot be their own referrer
+        if ($customer_id && (int) $referrer['id'] === (int) $customer_id) {
+            if (defined('WP_DEBUG') && WP_DEBUG) {
+                intersoccer_referral_log(sprintf(
+                    'InterSoccer Referral: Self-referral blocked for order #%d - customer %d attempted to use their own code %s',
+                    $order_id,
+                    $customer_id,
+                    $ref_code
+                ));
+            }
+            return;
+        }
 
         update_post_meta($order_id, '_intersoccer_referral_code', $ref_code);
         update_post_meta($order_id, '_intersoccer_referrer_type', $referrer['type']);
@@ -959,12 +989,13 @@ class InterSoccer_Referral_Handler {
 
     // Add credit field to checkout
     public function add_credit_field() {
-        $credits = intersoccer_get_customer_credits();
+        $credits = (float) intersoccer_get_customer_credits();
+        $credits_escaped = esc_attr( number_format( $credits, 2, '.', '' ) );
         ?>
         <div class="intersoccer-credits">
             <h3>Apply Credits</h3>
-            <p>Available: <span id="avail-credits"><?php echo $credits; ?> CHF</p>
-            <input type="range" id="credit-slider" name="intersoccer_apply_credits" min="0" max="<?php echo $credits; ?>" step="0.01" value="0">
+            <p>Available: <span id="avail-credits"><?php echo esc_html( number_format( $credits, 2 ) ); ?> CHF</p>
+            <input type="range" id="credit-slider" name="intersoccer_apply_credits" min="0" max="<?php echo $credits_escaped; ?>" step="0.01" value="0">
             <span id="credit-display">0 CHF</span>
             <button type="button" id="apply-max-credits">Apply Max</button>
         </div>


### PR DESCRIPTION
## Summary
This PR addresses multiple security vulnerabilities across the referral handler, admin settings, and audit log modules. Changes include input validation improvements, SQL injection prevention, output escaping for XSS protection, and business logic safeguards against self-referral and self-gifting.

## Key Changes

### Referral Handler (`class-referral-handler.php`)
- **Authentication check**: Added login verification in `handle_gift_credits()` to prevent unauthenticated credit gifting
- **Self-gifting prevention**: Added validation to prevent users from gifting credits to themselves
- **Self-referral prevention**: Added check in `process_referral_order()` to block customers from using their own referral codes
- **Output escaping**: Added `esc_html()` and `esc_attr()` calls in `render_gift_form()` and `add_credit_field()` to prevent XSS attacks
- **Type casting**: Explicitly cast credit values to float for consistency
- **Code formatting**: Applied WordPress coding standards (spacing, function call formatting)

### Admin Settings (`class-admin-settings.php`)
- **SQL injection prevention**: Replaced direct string interpolation in `check_database_tables()` with `$wpdb->prepare()` for table name validation
- **Security logging**: Removed debug logging of raw `$_POST` and `$_FILES` data to prevent sensitive information leakage
- **Improved logging**: Updated log messages to be more descriptive while avoiding exposure of request data
- **Input validation**: Added explicit type casting for file upload error codes

### Admin Audit (`class-admin-audit.php`)
- **SQL injection prevention**: Implemented column name whitelisting in `get_unique_values()` to prevent SQL injection via column interpolation
- **Prepared statements**: Ensured column names are properly quoted and validated before use in queries
- **Code clarity**: Added explanatory comments for security measures

## Notable Implementation Details
- The credit gifting bonus logic was clarified: the sender receives a 20-point bonus after the deduction, making the net cost `($amount - 20)` rather than `$amount`
- Column whitelisting in audit logs restricts queries to `event_type` and `category` only
- All user-facing numeric output is now properly escaped and formatted for display

https://claude.ai/code/session_01CRagBiveaZJzQhfTWHKBaz