### PR TITLE
Fix admin loyalty point adjustments using a stale ledger balance.

### DIFF
--- a/includes/class-admin-dashboard.php
+++ b/includes/class-admin-dashboard.php
@@ -958,10 +958,23 @@ class InterSoccer_Referral_Admin_Dashboard {
         if ($points_to_redeem > 0) {
             $user_id = (int) $order->get_customer_id();
             if ($user_id > 0) {
-                // Deduct points from user
-                $current_credits = get_user_meta($user_id, 'intersoccer_points_balance', true) ?: 0;
-                $new_credits = max(0, $current_credits - $points_to_redeem);
-                update_user_meta($user_id, 'intersoccer_points_balance', $new_credits);
+                $points_manager = InterSoccer_Points_Manager::get_instance();
+                $current_credits = $points_manager->get_points_balance($user_id);
+                $debit = min((int) $points_to_redeem, max(0, $current_credits));
+                if ($debit > 0) {
+                    $points_manager->add_points_transaction(
+                        $user_id,
+                        'points_redemption',
+                        -$debit,
+                        (int) $order_id,
+                        sprintf(
+                            __('Redeemed %d points on order #%d', 'intersoccer-referral'),
+                            $debit,
+                            $order_id
+                        )
+                    );
+                }
+                $new_credits = $points_manager->get_points_balance($user_id);
 
                 // Find the fee item for the discount
                 $fee_item_id = null;

--- a/includes/class-points-manager.php
+++ b/includes/class-points-manager.php
@@ -586,16 +586,27 @@ class InterSoccer_Points_Manager {
             return false;
         }
 
+        update_user_meta($customer_id, 'intersoccer_points_balance', (int) $new_balance);
+
         return $wpdb->insert_id;
     }
 
     /**
-     * Get current points balance for a customer
-     * 
+     * Get current redeemable points balance for a customer.
+     *
+     * User meta is the balance shown in admin and at checkout. Ledger last-row
+     * is a fallback when meta has never been written. A stored 0 is a real
+     * balance (do not treat it as missing).
+     *
      * @param int $customer_id The customer's user ID
      * @return int The customer's current points balance (integer only)
      */
     public function get_points_balance($customer_id) {
+        $meta = get_user_meta($customer_id, 'intersoccer_points_balance', true);
+        if ($meta !== '' && $meta !== false && $meta !== null) {
+            return intval($meta);
+        }
+
         global $wpdb;
 
         $balance = $wpdb->get_var($wpdb->prepare(

--- a/tests/OrderCompletionSessionTest.php
+++ b/tests/OrderCompletionSessionTest.php
@@ -11,6 +11,7 @@ class OrderCompletionSessionTest extends TestCase {
 
     protected function setUp(): void {
         require_once __DIR__ . '/../includes/class-admin-dashboard.php';
+        require_once __DIR__ . '/../includes/class-points-manager.php';
 
         $reflection = new ReflectionClass(InterSoccer_Referral_Admin_Dashboard::class);
         $this->dashboard = $reflection->newInstanceWithoutConstructor();

--- a/tests/PointsManagerTest.php
+++ b/tests/PointsManagerTest.php
@@ -26,12 +26,13 @@ class PointsManagerTest extends TestCase {
     }
 
     private function resetPointsTestState(): void {
-        global $mock_points_balances, $mock_order_points_allocated, $mock_points_log_rows, $mock_wc_orders_by_id, $mock_wc_get_orders, $mock_user_roles, $mock_customer_spent, $mock_session;
+        global $mock_points_balances, $mock_order_points_allocated, $mock_points_log_rows, $mock_wc_orders_by_id, $mock_wc_get_orders, $mock_user_roles, $mock_customer_spent, $mock_session, $mock_user_meta;
 
         $this->resetPointsManagerSingleton();
         $mock_points_balances = [];
         $mock_order_points_allocated = [];
         $mock_points_log_rows = [];
+        $mock_user_meta = [];
         $mock_wc_orders_by_id = [];
         $mock_wc_get_orders = null;
         $mock_user_roles = [];
@@ -231,6 +232,26 @@ class PointsManagerTest extends TestCase {
         $balance = $points_manager->get_points_balance(1);
         $this->assertEquals(35, $balance);
         $this->assertIsInt($balance, 'Balance must be integer only');
+    }
+
+    /**
+     * Admin Add must use the displayed (usermeta) balance when it diverges from
+     * the last ledger running total (e.g. checkout redeemed from meta only).
+     */
+    public function testAdminAddUsesMetaWhenLedgerDiverged() {
+        $points_manager = new InterSoccer_Points_Manager();
+
+        global $mock_points_balances, $mock_user_meta;
+        $mock_points_balances[44500] = 52;
+        $mock_user_meta[44500] = [
+            'intersoccer_points_balance' => 0,
+        ];
+
+        $points_manager->add_points_transaction(44500, 'admin_adjustment', 30, null, 'debug');
+
+        $this->assertSame(30, $points_manager->get_points_balance(44500));
+        $this->assertSame(30, (int) get_user_meta(44500, 'intersoccer_points_balance', true));
+        $this->assertSame(30, (int) $mock_points_balances[44500]);
     }
 
     /**


### PR DESCRIPTION
Checkout redeemed from usermeta only, so Add used the last ledger total and overwrote the displayed balance. Base adjustments on the redeemable meta balance and write redemptions into the points log.